### PR TITLE
Preparation: Ensure version of cpprb < 8.0.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, Extension, find_packages
 
 install_requires = [
-    "cpprb>=7.13.3"
+    "cpprb>=7.13.3,<8.0.0"
     "joblib",
     "scipy"
 ]


### PR DESCRIPTION
cpprb is scheduled to break its api drastically in
v8. (cpprb.experimental -> cpprb)

The current version of tf2rl ensures to use cpprb v7.

After cpprb officially update to v8 and tf2rl become ready, then "<"
will be replaced with ">=".

This PR is related with issue #43 