### PR TITLE
[Feature] Update priority only at no change

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, Extension, find_packages
 
 install_requires = [
-    "cpprb>=8.0.0",
+    "cpprb>=8.1.1",
     "setuptools>=41.0.0",
     "numpy>=1.16.0",
     "joblib",

--- a/tf2rl/algos/apex.py
+++ b/tf2rl/algos/apex.py
@@ -224,10 +224,12 @@ def learner(global_rb, trained_steps, is_training_done,
         tf.summary.experimental.set_step(trained_steps.value)
         lock.acquire()
         samples = global_rb.sample(policy.batch_size)
+        lock.release()
         td_errors = policy.train(
             samples["obs"], samples["act"], samples["next_obs"],
             samples["rew"], samples["done"], samples["weights"])
         writer.flush()
+        lock.acquire()
         global_rb.update_priorities(
             samples["indexes"], np.abs(td_errors)+1e-6)
         lock.release()

--- a/tf2rl/algos/apex.py
+++ b/tf2rl/algos/apex.py
@@ -378,6 +378,7 @@ def prepare_experiment(env, args):
     manager.start()
 
     kwargs = get_default_rb_dict(args.replay_buffer_size, env)
+    kwargs["check_for_update"] = True
     global_rb = manager.PrioritizedReplayBuffer(**kwargs)
 
     # queues to share network parameters between a learner and explorers


### PR DESCRIPTION
See #62

To separate lock for `sample` and `update_priorities`, update the priorities only at unchanged indexes after the last `PrioritizedReplayBuffer.sampe`.

 `cpprb` > v8.1 adds new boolean keyword `check_for_update` (default `False`) in the `PrioritizedReplayBuffer.__init__` constructor, which traces whether the indexes are update or not after `sample` member function, and which skips indexes at already changed in `update_priorities` method function.