### PR TITLE
Feature multiplatform GitHub Actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -56,3 +56,4 @@ jobs:
         working-directory: './tests'
       - run: ./test_run_examples.sh
         shell: bash
+        if: ((startsWith(runner.os, 'Windows') != true) || (matrix.python == '3.7'))

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,58 @@
+name: Test
+
+on: [push, pull_request]
+
+
+jobs:
+  test:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        python: ['3.7', '3.8']
+        TF: ['2.2', '2.3']
+        include:
+          - os: ubuntu-latest
+            python: '3.7'
+            TF: '2.0'
+          - os: ubuntu-latest
+            python: '3.7'
+            TF: '2.1'
+          - os: macos-latest
+            python: '3.7'
+            TF: '2.0'
+          - os: macos-latest
+            python: '3.7'
+            TF: '2.1'
+          - os: windows-latest
+            python: '3.7'
+            TF: '2.0'
+          - os: windows-latest
+            python: '3.7'
+            TF: '2.1'
+      fail-fast: false
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python }}
+      - name: Get pip cache dir
+        id: pip-cache
+        run: echo "::set-output name=dir::$(pip cache dir)"
+      - name: pip cache
+        uses: actions/cache@v2
+        with:
+          path: ${{ steps.pip-cache.outputs.dir }}
+          key: ${{ runner.os }}-pip${{ matrix.python }}-${{ matrix.TF }}
+          restore-keys: |
+            ${{ runner.os }}-pip${{ matrix.python }}-
+      - run: pip install wheel
+      - name: Install cpprb for macOS
+        if: startsWith(runner.os, 'macOS')
+        run: CC=gcc-9 CXX=g++-9 pip install cpprb
+      - run: pip install tensorflow==${{ matrix.TF }}'.*'
+      - run: pip install '.[test]'
+      - run: python -m unittest discover .
+        working-directory: './tests'
+      - run: ./test_run_examples.sh
+        shell: bash

--- a/examples/run_apex_ddpg.py
+++ b/examples/run_apex_ddpg.py
@@ -5,6 +5,48 @@ from tf2rl.algos.ddpg import DDPG
 from tf2rl.misc.target_update_ops import update_target_variables
 
 
+# Prepare env and policy function
+class env_fn:
+    def __init__(self,env_name):
+        self.env_name = env_name
+
+    def __call__(self):
+        return gym.make(self.env_name)
+
+def policy_fn(env, name, memory_capacity=int(1e6),
+              gpu=-1, noise_level=0.3):
+    return DDPG(
+        state_shape=env.observation_space.shape,
+        action_dim=env.action_space.high.size,
+        max_action=env.action_space.high[0],
+        gpu=gpu,
+        name=name,
+        sigma=noise_level,
+        batch_size=100,
+        lr_actor=0.001,
+        lr_critic=0.001,
+        actor_units=[400, 300],
+        critic_units=[400, 300],
+        memory_capacity=memory_capacity)
+
+def get_weights_fn(policy):
+    # TODO: Check if following needed
+    import tensorflow as tf
+    with tf.device(policy.device):
+        return [policy.actor.weights,
+                policy.critic.weights,
+                policy.critic_target.weights]
+
+def set_weights_fn(policy, weights):
+    actor_weights, critic_weights, critic_target_weights = weights
+    update_target_variables(
+        policy.actor.weights, actor_weights, tau=1.)
+    update_target_variables(
+        policy.critic.weights, critic_weights, tau=1.)
+    update_target_variables(
+        policy.critic_target.weights, critic_target_weights, tau=1.)
+
+
 if __name__ == '__main__':
     parser = apex_argument()
     parser.add_argument('--env-name', type=str,
@@ -12,41 +54,4 @@ if __name__ == '__main__':
     parser = DDPG.get_argument(parser)
     args = parser.parse_args()
 
-    # Prepare env and policy function
-    def env_fn():
-        return gym.make(args.env_name)
-
-    def policy_fn(env, name, memory_capacity=int(1e6),
-                  gpu=-1, noise_level=0.3):
-        return DDPG(
-            state_shape=env.observation_space.shape,
-            action_dim=env.action_space.high.size,
-            max_action=env.action_space.high[0],
-            gpu=gpu,
-            name=name,
-            sigma=noise_level,
-            batch_size=100,
-            lr_actor=0.001,
-            lr_critic=0.001,
-            actor_units=[400, 300],
-            critic_units=[400, 300],
-            memory_capacity=memory_capacity)
-
-    def get_weights_fn(policy):
-        # TODO: Check if following needed
-        import tensorflow as tf
-        with tf.device(policy.device):
-            return [policy.actor.weights,
-                    policy.critic.weights,
-                    policy.critic_target.weights]
-
-    def set_weights_fn(policy, weights):
-        actor_weights, critic_weights, critic_target_weights = weights
-        update_target_variables(
-            policy.actor.weights, actor_weights, tau=1.)
-        update_target_variables(
-            policy.critic.weights, critic_weights, tau=1.)
-        update_target_variables(
-            policy.critic_target.weights, critic_target_weights, tau=1.)
-
-    run(args, env_fn, policy_fn, get_weights_fn, set_weights_fn)
+    run(args, env_fn(args.env_name), policy_fn, get_weights_fn, set_weights_fn)

--- a/examples/run_apex_dqn.py
+++ b/examples/run_apex_dqn.py
@@ -9,6 +9,60 @@ from tf2rl.misc.target_update_ops import update_target_variables
 from tf2rl.networks.atari_model import AtariQFunc
 
 
+# Prepare env and policy function
+class env_fn:
+    def __init__(self,env_name):
+        self.env_name = env_name
+
+    def __call__(self):
+        return gym.make(self.env_name)
+
+class policy_fn:
+    def __init__(self,args,n_warmup,target_replace_interval,batch_size,
+                 optimizer,epsilon_decay_rate,QFunc):
+        self.args = args
+        self.n_warmup = n_warmup
+        self.target_replace_interval = target_replace_interval
+        self.batch_size = batch_size
+        self.optimizer = optimizer
+        self.epsilon_decay_rate = epsilon_decay_rate
+        self.QFunc = QFunc
+
+    def __call__(self,env, name, memory_capacity=int(1e6),
+                 gpu=-1, noise_level=0.3):
+        return DQN(
+            name=name,
+            enable_double_dqn=self.args.enable_double_dqn,
+            enable_dueling_dqn=self.args.enable_dueling_dqn,
+            enable_noisy_dqn=self.args.enable_noisy_dqn,
+            enable_categorical_dqn=self.args.enable_categorical_dqn,
+            state_shape=env.observation_space.shape,
+            action_dim=env.action_space.n,
+            n_warmup=self.n_warmup,
+            target_replace_interval=self.target_replace_interval,
+            batch_size=self.batch_size,
+            memory_capacity=memory_capacity,
+            discount=0.99,
+            epsilon=1.,
+            epsilon_min=0.1,
+            epsilon_decay_step=self.epsilon_decay_rate,
+            optimizer=self.optimizer,
+            update_interval=4,
+            q_func=self.QFunc,
+            gpu=gpu)
+
+def get_weights_fn(policy):
+    return [policy.q_func.weights,
+            policy.q_func_target.weights]
+
+def set_weights_fn(policy, weights):
+    q_func_weights, qfunc_target_weights = weights
+    update_target_variables(
+        policy.q_func.weights, q_func_weights, tau=1.)
+    update_target_variables(
+        policy.q_func_target.weights, qfunc_target_weights, tau=1.)
+
+
 if __name__ == '__main__':
     parser = apex_argument()
     parser = DQN.get_argument(parser)
@@ -35,42 +89,7 @@ if __name__ == '__main__':
         epsilon_decay_rate = int(1e3)
         QFunc = None
 
-    # Prepare env and policy function
-    def env_fn():
-        return gym.make(env_name)
-
-    def policy_fn(env, name, memory_capacity=int(1e6),
-                  gpu=-1, noise_level=0.3):
-        return DQN(
-            name=name,
-            enable_double_dqn=args.enable_double_dqn,
-            enable_dueling_dqn=args.enable_dueling_dqn,
-            enable_noisy_dqn=args.enable_noisy_dqn,
-            enable_categorical_dqn=args.enable_categorical_dqn,
-            state_shape=env.observation_space.shape,
-            action_dim=env.action_space.n,
-            n_warmup=n_warmup,
-            target_replace_interval=target_replace_interval,
-            batch_size=batch_size,
-            memory_capacity=memory_capacity,
-            discount=0.99,
-            epsilon=1.,
-            epsilon_min=0.1,
-            epsilon_decay_step=epsilon_decay_rate,
-            optimizer=optimizer,
-            update_interval=4,
-            q_func=QFunc,
-            gpu=gpu)
-
-    def get_weights_fn(policy):
-        return [policy.q_func.weights,
-                policy.q_func_target.weights]
-
-    def set_weights_fn(policy, weights):
-        q_func_weights, qfunc_target_weights = weights
-        update_target_variables(
-            policy.q_func.weights, q_func_weights, tau=1.)
-        update_target_variables(
-            policy.q_func_target.weights, qfunc_target_weights, tau=1.)
-
-    run(args, env_fn, policy_fn, get_weights_fn, set_weights_fn)
+    run(args, env_fn(env_name),
+        policy_fn(args,n_warmup,target_replace_interval,batch_size,optimizer,
+                  epsilon_decay_rate,QFunc),
+        get_weights_fn, set_weights_fn)

--- a/test_run_examples.sh
+++ b/test_run_examples.sh
@@ -1,4 +1,6 @@
-#!/bin/bash -eu
+#!/bin/bash
+
+set -eu
 
 prefix="python -u"
 common_arg="--gpu -1 --logging-level WARNING --max-steps 256 --batch-size 32 --dir-suffix TEST"

--- a/tests/algos/test_apex.py
+++ b/tests/algos/test_apex.py
@@ -26,33 +26,8 @@ class TestApeX(unittest.TestCase):
         parser.set_defaults(n_warmup=1)
         args, _ = parser.parse_known_args()
 
-        def env_fn():
-            return gym.make("CartPole-v0")
-
-        def policy_fn(env, name, memory_capacity=int(1e6), gpu=-1, *args, **kwargs):
-            return DQN(
-                name=name,
-                state_shape=env.observation_space.shape,
-                action_dim=env.action_space.n,
-                n_warmup=500,
-                target_replace_interval=300,
-                batch_size=32,
-                memory_capacity=memory_capacity,
-                discount=0.99,
-                gpu=-1)
-
-        def get_weights_fn(policy):
-            return [policy.q_func.weights,
-                    policy.q_func_target.weights]
-
-        def set_weights_fn(policy, weights):
-            q_func_weights, qfunc_target_weights = weights
-            update_target_variables(
-                policy.q_func.weights, q_func_weights, tau=1.)
-            update_target_variables(
-                policy.q_func_target.weights, qfunc_target_weights, tau=1.)
-
-        run(args, env_fn, policy_fn, get_weights_fn, set_weights_fn)
+        run(args, env_fn_discrete, policy_fn_discrete,
+            get_weights_fn_discrete, set_weights_fn_discrete)
 
     def test_run_continuous(self):
         from tf2rl.algos.ddpg import DDPG
@@ -60,32 +35,65 @@ class TestApeX(unittest.TestCase):
         parser.set_defaults(n_warmup=1)
         args, _ = parser.parse_known_args()
 
-        def env_fn():
-            return gym.make('Pendulum-v0')
+        run(args, env_fn_continuous, policy_fn_continuous,
+            get_weights_fn_continuous, set_weights_fn_continuous)
 
-        def policy_fn(env, name, memory_capacity=int(1e6), gpu=-1, *args, **kwargs):
-            return DDPG(
-                state_shape=env.observation_space.shape,
-                action_dim=env.action_space.high.size,
-                n_warmup=500,
-                gpu=-1)
 
-        def get_weights_fn(policy):
-            return [policy.actor.weights,
-                    policy.critic.weights,
-                    policy.critic_target.weights]
+def env_fn_discrete():
+    return gym.make("CartPole-v0")
 
-        def set_weights_fn(policy, weights):
-            actor_weights, critic_weights, critic_target_weights = weights
-            update_target_variables(
-                policy.actor.weights, actor_weights, tau=1.)
-            update_target_variables(
-                policy.critic.weights, critic_weights, tau=1.)
-            update_target_variables(
-                policy.critic_target.weights, critic_target_weights, tau=1.)
+def policy_fn_discrete(env, name, memory_capacity=int(1e6), gpu=-1, *args, **kwargs):
+    from tf2rl.algos.dqn import DQN
+    return DQN(
+        name=name,
+        state_shape=env.observation_space.shape,
+        action_dim=env.action_space.n,
+        n_warmup=500,
+        target_replace_interval=300,
+        batch_size=32,
+        memory_capacity=memory_capacity,
+        discount=0.99,
+        gpu=-1)
 
-        run(args, env_fn, policy_fn, get_weights_fn, set_weights_fn)
+def get_weights_fn_discrete(policy):
+    return [policy.q_func.weights,
+            policy.q_func_target.weights]
 
+def set_weights_fn_discrete(policy, weights):
+    q_func_weights, qfunc_target_weights = weights
+    update_target_variables(
+        policy.q_func.weights, q_func_weights, tau=1.)
+    update_target_variables(
+        policy.q_func_target.weights, qfunc_target_weights, tau=1.)
+
+
+def env_fn_continuous():
+    return gym.make('Pendulum-v0')
+
+
+def policy_fn_continuous(env, name, memory_capacity=int(1e6), gpu=-1, *args, **kwargs):
+    from tf2rl.algos.ddpg import DDPG
+    return DDPG(
+        state_shape=env.observation_space.shape,
+        action_dim=env.action_space.high.size,
+        n_warmup=500,
+        gpu=-1)
+
+
+def get_weights_fn_continuous(policy):
+    return [policy.actor.weights,
+            policy.critic.weights,
+            policy.critic_target.weights]
+
+
+def set_weights_fn_continuous(policy, weights):
+    actor_weights, critic_weights, critic_target_weights = weights
+    update_target_variables(
+        policy.actor.weights, actor_weights, tau=1.)
+    update_target_variables(
+        policy.critic.weights, critic_weights, tau=1.)
+    update_target_variables(
+        policy.critic_target.weights, critic_target_weights, tau=1.)
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/envs/test_atari_wrapper.py
+++ b/tests/envs/test_atari_wrapper.py
@@ -1,3 +1,5 @@
+import platform
+import sys
 import unittest
 
 import numpy as np
@@ -5,7 +7,8 @@ import gym
 
 from tf2rl.envs.atari_wrapper import wrap_dqn
 
-
+@unittest.skipIf((platform.system() == 'Windows') and (sys.version_info.minor >= 8),
+                 "atari-py doesn't work at Windows with Python3.8 and later")
 class TestAtariWrapper(unittest.TestCase):
     def test_wrap_dqn(self):
         env = wrap_dqn(gym.make("SpaceInvadersNoFrameskip-v4"), wrap_ndarray=True)


### PR DESCRIPTION
This PR adds multi-platform unit test at GitHub Actions. (#96)
* OS
  * Windows
  * macOS
  * Linux
* Python
  * 3.7
  * 3.8
* TensorFlow
  * 2.0 (Python 3.7 only)
  * 2.1 (Python 3.7 only)
  * 2.2
  * 2.3

Additionally, in order to pass the test, some Windows specific problems are solved or skipped.
* shebang is ignored (75ac408)
* only top level class/function can be used at `multiprocessing` (3321da2)
* atari-py cannot work at Windows with Python 3.8 (79d6780, 0a6b232)