### PR TITLE
Reduce tf.function retracing

### DIFF
--- a/tf2rl/algos/ddpg.py
+++ b/tf2rl/algos/ddpg.py
@@ -97,7 +97,8 @@ class DDPG(OffPolicyAgent):
         state = np.expand_dims(state, axis=0).astype(
             np.float32) if is_single_state else state
         action = self._get_action_body(
-            tf.constant(state), self.sigma * (1. - test),
+            tf.constant(state),
+            tf.constant(self.sigma * (1. - test), dtype=tf.float32),
             tf.constant(self.actor.max_action, dtype=tf.float32))
         if tensor:
             return action

--- a/tf2rl/algos/dqn.py
+++ b/tf2rl/algos/dqn.py
@@ -192,7 +192,8 @@ class DQN(OffPolicyAgent):
         if weights is None:
             weights = np.ones_like(rewards)
         td_errors, q_func_loss = self._train_body(
-            states, actions, next_states, rewards, done, weights)
+            tf.constant(states), tf.constant(actions), tf.constant(next_states),
+            tf.constant(rewards), tf.constant(done), tf.constant(weights))
 
         tf.summary.scalar(name=self.policy_name +
                           "/q_func_Loss", data=q_func_loss)

--- a/tf2rl/algos/sac.py
+++ b/tf2rl/algos/sac.py
@@ -114,7 +114,7 @@ class SAC(OffPolicyAgent):
 
         state = np.expand_dims(state, axis=0).astype(
             np.float32) if is_single_state else state
-        action = self._get_action_body(tf.constant(state), test)
+        action = self._get_action_body(tf.constant(state), tf.constant(test))
 
         return action.numpy()[0] if is_single_state else action
 

--- a/tf2rl/algos/vpg.py
+++ b/tf2rl/algos/vpg.py
@@ -93,7 +93,8 @@ class VPG(OnPolicyAgent):
         is_single_input = state.ndim == self._state_ndim
         if is_single_input:
             state = np.expand_dims(state, axis=0).astype(np.float32)
-        action, logp, _ = self._get_action_body(state, test)
+        action, logp, _ = self._get_action_body(tf.constant(state, dtype=tf.float32),
+                                                tf.constant(test))
 
         if is_single_input:
             return action.numpy()[0], logp.numpy()


### PR DESCRIPTION
This PR ensures input arguments of graph function (decorated by tf.function) as tf.Tensor instead of pure Python object, in order to reduce tf.function retracing.

Related with #99 



