### PR TITLE
Feature: Linter (flake8) on GitHub Actions

### DIFF
--- a/.github/linters/.flake8
+++ b/.github/linters/.flake8
@@ -1,0 +1,3 @@
+[flake8]
+ignore = E129,E226,E303,E501,W503,W504,E741
+exclude = .git,__pycache__,egg-info,.eggs,prepare_output_dir.py

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -1,0 +1,14 @@
+name: Lint Code
+
+on: [push, pull_request]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: docker://github/super-linter:v3
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VALIDATE_PYTHON_FLAKE8: true
+          PYTHON_FLAKE8_CONFIG_FILE: ".flake8"

--- a/examples/run_apex_ddpg.py
+++ b/examples/run_apex_ddpg.py
@@ -7,11 +7,12 @@ from tf2rl.misc.target_update_ops import update_target_variables
 
 # Prepare env and policy function
 class env_fn:
-    def __init__(self,env_name):
+    def __init__(self, env_name):
         self.env_name = env_name
 
     def __call__(self):
         return gym.make(self.env_name)
+
 
 def policy_fn(env, name, memory_capacity=int(1e6),
               gpu=-1, noise_level=0.3):
@@ -29,6 +30,7 @@ def policy_fn(env, name, memory_capacity=int(1e6),
         critic_units=[400, 300],
         memory_capacity=memory_capacity)
 
+
 def get_weights_fn(policy):
     # TODO: Check if following needed
     import tensorflow as tf
@@ -36,6 +38,7 @@ def get_weights_fn(policy):
         return [policy.actor.weights,
                 policy.critic.weights,
                 policy.critic_target.weights]
+
 
 def set_weights_fn(policy, weights):
     actor_weights, critic_weights, critic_target_weights = weights

--- a/examples/run_apex_dqn.py
+++ b/examples/run_apex_dqn.py
@@ -1,5 +1,3 @@
-import argparse
-import numpy as np
 import gym
 import tensorflow as tf
 
@@ -11,15 +9,16 @@ from tf2rl.networks.atari_model import AtariQFunc
 
 # Prepare env and policy function
 class env_fn:
-    def __init__(self,env_name):
+    def __init__(self, env_name):
         self.env_name = env_name
 
     def __call__(self):
         return gym.make(self.env_name)
 
+
 class policy_fn:
-    def __init__(self,args,n_warmup,target_replace_interval,batch_size,
-                 optimizer,epsilon_decay_rate,QFunc):
+    def __init__(self, args, n_warmup, target_replace_interval, batch_size,
+                 optimizer, epsilon_decay_rate, QFunc):
         self.args = args
         self.n_warmup = n_warmup
         self.target_replace_interval = target_replace_interval
@@ -28,7 +27,7 @@ class policy_fn:
         self.epsilon_decay_rate = epsilon_decay_rate
         self.QFunc = QFunc
 
-    def __call__(self,env, name, memory_capacity=int(1e6),
+    def __call__(self, env, name, memory_capacity=int(1e6),
                  gpu=-1, noise_level=0.3):
         return DQN(
             name=name,
@@ -51,9 +50,11 @@ class policy_fn:
             q_func=self.QFunc,
             gpu=gpu)
 
+
 def get_weights_fn(policy):
     return [policy.q_func.weights,
             policy.q_func_target.weights]
+
 
 def set_weights_fn(policy, weights):
     q_func_weights, qfunc_target_weights = weights
@@ -90,6 +91,6 @@ if __name__ == '__main__':
         QFunc = None
 
     run(args, env_fn(env_name),
-        policy_fn(args,n_warmup,target_replace_interval,batch_size,optimizer,
-                  epsilon_decay_rate,QFunc),
+        policy_fn(args, n_warmup, target_replace_interval, batch_size, optimizer,
+                  epsilon_decay_rate, QFunc),
         get_weights_fn, set_weights_fn)

--- a/examples/run_ppo_atari.py
+++ b/examples/run_ppo_atari.py
@@ -1,7 +1,5 @@
 import gym
 
-import numpy as np
-import tensorflow as tf
 
 from tf2rl.algos.ppo import PPO
 from tf2rl.envs.atari_wrapper import wrap_dqn

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-from setuptools import setup, Extension, find_packages
+from setuptools import setup, find_packages
 
 install_requires = [
     "cpprb>=8.1.1",

--- a/tests/algos/__init__.py
+++ b/tests/algos/__init__.py
@@ -1,1 +1,0 @@
-from .common import CommonAlgos

--- a/tests/algos/test_apex.py
+++ b/tests/algos/test_apex.py
@@ -2,8 +2,6 @@
 
 import unittest
 import gym
-import numpy as np
-import tensorflow as tf
 
 from tf2rl.algos.apex import apex_argument, run
 from tf2rl.misc.target_update_ops import update_target_variables
@@ -42,6 +40,7 @@ class TestApeX(unittest.TestCase):
 def env_fn_discrete():
     return gym.make("CartPole-v0")
 
+
 def policy_fn_discrete(env, name, memory_capacity=int(1e6), gpu=-1, *args, **kwargs):
     from tf2rl.algos.dqn import DQN
     return DQN(
@@ -55,9 +54,11 @@ def policy_fn_discrete(env, name, memory_capacity=int(1e6), gpu=-1, *args, **kwa
         discount=0.99,
         gpu=-1)
 
+
 def get_weights_fn_discrete(policy):
     return [policy.q_func.weights,
             policy.q_func_target.weights]
+
 
 def set_weights_fn_discrete(policy, weights):
     q_func_weights, qfunc_target_weights = weights
@@ -94,6 +95,7 @@ def set_weights_fn_continuous(policy, weights):
         policy.critic.weights, critic_weights, tau=1.)
     update_target_variables(
         policy.critic_target.weights, critic_target_weights, tau=1.)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/algos/test_bi_res_ddpg.py
+++ b/tests/algos/test_bi_res_ddpg.py
@@ -1,6 +1,4 @@
 import unittest
-import numpy as np
-import tensorflow as tf
 
 from tf2rl.algos.bi_res_ddpg import BiResDDPG
 from tests.algos.common import CommonOffPolContinuousAlgos

--- a/tests/algos/test_ppo.py
+++ b/tests/algos/test_ppo.py
@@ -1,7 +1,4 @@
 import unittest
-import gym
-import numpy as np
-import tensorflow as tf
 
 from tf2rl.algos.ppo import PPO
 from tests.algos.common import CommonOnPolActorCriticContinuousAlgos, CommonOnPolActorCriticDiscreteAlgos

--- a/tests/algos/test_td3.py
+++ b/tests/algos/test_td3.py
@@ -1,6 +1,4 @@
 import unittest
-import numpy as np
-import tensorflow as tf
 
 from tf2rl.algos.td3 import TD3
 from tests.algos.common import CommonOffPolContinuousAlgos

--- a/tests/algos/test_vpg.py
+++ b/tests/algos/test_vpg.py
@@ -1,7 +1,4 @@
 import unittest
-import gym
-import numpy as np
-import tensorflow as tf
 
 from tf2rl.algos.vpg import VPG
 from tests.algos.common import CommonOnPolActorCriticContinuousAlgos, CommonOnPolActorCriticDiscreteAlgos

--- a/tests/distributions/test_diagonal_gaussian.py
+++ b/tests/distributions/test_diagonal_gaussian.py
@@ -10,7 +10,7 @@ class TestDiagonalGaussian(CommonDist):
     def setUpClass(cls):
         super().setUpClass()
         cls.dist = DiagonalGaussian(dim=cls.dim)
-        cls.param = param = {
+        cls.param = {
             "mean": np.zeros(shape=(1, cls.dim), dtype=np.float32),
             "log_std": np.ones(shape=(1, cls.dim), dtype=np.float32)*np.log(1.)}
         cls.params = {

--- a/tests/envs/test_atari_wrapper.py
+++ b/tests/envs/test_atari_wrapper.py
@@ -7,6 +7,7 @@ import gym
 
 from tf2rl.envs.atari_wrapper import wrap_dqn
 
+
 @unittest.skipIf((platform.system() == 'Windows') and (sys.version_info.minor >= 8),
                  "atari-py doesn't work at Windows with Python3.8 and later")
 class TestAtariWrapper(unittest.TestCase):

--- a/tests/envs/test_multi_thread_env.py
+++ b/tests/envs/test_multi_thread_env.py
@@ -1,6 +1,5 @@
 import unittest
 import gym
-import numpy as np
 import tensorflow as tf
 
 from tf2rl.envs.multi_thread_env import MultiThreadEnv
@@ -12,14 +11,19 @@ class TestMultiThreadEnv(unittest.TestCase):
         cls.batch_size = 64
         cls.thread_pool = 4
         cls.max_episode_steps = 1000
-        def env_fn(): return gym.make("Pendulum-v0")
+
+        def env_fn():
+            return gym.make("Pendulum-v0")
+
         cls.continuous_sample_env = env_fn()
         cls.continuous_envs = MultiThreadEnv(
             env_fn=env_fn,
             batch_size=cls.batch_size,
             max_episode_steps=cls.max_episode_steps)
 
-        def env_fn(): return gym.make("CartPole-v0")
+        def env_fn():
+            return gym.make("CartPole-v0")
+
         cls.discrete_sample_env = env_fn()
         cls.discrete_envs = MultiThreadEnv(
             env_fn=env_fn,

--- a/tests/misc/test_get_replay_buffer.py
+++ b/tests/misc/test_get_replay_buffer.py
@@ -1,7 +1,5 @@
 import unittest
 
-import os
-import numpy as np
 import gym
 
 from cpprb import ReplayBuffer

--- a/tests/policies/test_categorical_actor.py
+++ b/tests/policies/test_categorical_actor.py
@@ -1,6 +1,5 @@
 import unittest
 import numpy as np
-import tensorflow as tf
 
 from tf2rl.policies.categorical_actor import CategoricalActor
 from tests.policies.common import CommonModel

--- a/tests/policies/test_gaussian_actor.py
+++ b/tests/policies/test_gaussian_actor.py
@@ -1,6 +1,5 @@
 import unittest
 import numpy as np
-import tensorflow as tf
 
 from tf2rl.policies.gaussian_actor import GaussianActor
 from tests.policies.common import CommonModel

--- a/tf2rl/algos/apex.py
+++ b/tf2rl/algos/apex.py
@@ -3,7 +3,7 @@ import numpy as np
 import argparse
 import logging
 import multiprocessing
-from multiprocessing import Process, Queue, Value, Event, Lock
+from multiprocessing import Process, Value, Event
 from multiprocessing.managers import SyncManager
 
 from cpprb import ReplayBuffer, PrioritizedReplayBuffer

--- a/tf2rl/algos/policy_base.py
+++ b/tf2rl/algos/policy_base.py
@@ -1,4 +1,3 @@
-import numpy as np
 import tensorflow as tf
 
 

--- a/tf2rl/algos/td3.py
+++ b/tf2rl/algos/td3.py
@@ -2,7 +2,7 @@ import numpy as np
 import tensorflow as tf
 from tensorflow.keras.layers import Dense
 
-from tf2rl.algos.ddpg import DDPG, Actor
+from tf2rl.algos.ddpg import DDPG
 from tf2rl.misc.target_update_ops import update_target_variables
 from tf2rl.misc.huber_loss import huber_loss
 

--- a/tf2rl/distributions/categorical.py
+++ b/tf2rl/distributions/categorical.py
@@ -1,4 +1,3 @@
-import numpy as np
 import tensorflow as tf
 
 from tf2rl.distributions.base import Distribution

--- a/tf2rl/envs/utils.py
+++ b/tf2rl/envs/utils.py
@@ -21,14 +21,12 @@ def get_act_dim(action_space):
 
 
 def is_mujoco_env(env):
-    from gym.envs import mujoco
     if not hasattr(env, "env"):
         return False
     return gym.envs.mujoco.mujoco_env.MujocoEnv in env.env.__class__.__bases__
 
 
 def is_atari_env(env):
-    from gym.envs import atari
     if not hasattr(env, "env"):
         return False
     return gym.envs.atari.atari_env.AtariEnv == env.env.__class__

--- a/tf2rl/experiments/utils.py
+++ b/tf2rl/experiments/utils.py
@@ -1,11 +1,9 @@
 import os
-import random
 
 import numpy as np
 import joblib
 import matplotlib.pyplot as plt
 from matplotlib import animation
-import tensorflow as tf
 
 
 def save_path(samples, filename):

--- a/tf2rl/misc/get_replay_buffer.py
+++ b/tf2rl/misc/get_replay_buffer.py
@@ -1,7 +1,6 @@
 import numpy as np
 from gym.spaces.box import Box
 from gym.spaces.discrete import Discrete
-from gym.spaces.dict import Dict
 
 from cpprb import ReplayBuffer, PrioritizedReplayBuffer
 

--- a/tf2rl/misc/huber_loss.py
+++ b/tf2rl/misc/huber_loss.py
@@ -1,4 +1,3 @@
-import numpy as np
 import tensorflow as tf
 
 

--- a/tf2rl/networks/spectral_norm_dense.py
+++ b/tf2rl/networks/spectral_norm_dense.py
@@ -1,6 +1,4 @@
-import numpy as np
 import tensorflow as tf
-from tensorflow.keras import backend as K
 from tensorflow.keras.layers import Dense
 from tensorflow.python.eager import context
 from tensorflow.python.framework import common_shapes
@@ -52,7 +50,7 @@ class SNDense(Dense):
         rank = common_shapes.rank(inputs)
         if rank > 2:
             # Broadcasting is required for the inputs.
-            outputs = standard_ops.tensordot(inputs, w, [[rank - 1], [0]])
+            outputs = tf.tensordot(inputs, w, [[rank - 1], [0]])
             # Reshape the output back to the original ndim of the input.
             if not context.executing_eagerly():
                 shape = inputs.get_shape().as_list()

--- a/tf2rl/tools/vae.py
+++ b/tf2rl/tools/vae.py
@@ -66,8 +66,6 @@ if __name__ == "__main__":
     import PIL
     import imageio
 
-    from IPython import display
-
     (train_images, _), (test_images, _) = tf.keras.datasets.fashion_mnist.load_data()
     train_images = train_images.reshape(train_images.shape[0], 28, 28, 1).astype('float32')
     test_images = test_images.reshape(test_images.shape[0], 28, 28, 1).astype('float32')
@@ -134,7 +132,7 @@ if __name__ == "__main__":
     def generate_and_save_images(model, epoch, test_input):
         predictions = model.sample(test_input)
         plt.close()
-        fig = plt.figure(figsize=(4, 4))
+        plt.figure(figsize=(4, 4))
 
         for i in range(predictions.shape[0]):
             plt.subplot(4, 4, i + 1)


### PR DESCRIPTION
For #101


This PR adds a job on GitHub Actions to run [flake8](https://gitlab.com/pycqa/flake8) (Linter) at push and pull request.

This utilizes [GitHub Super-Linter](https://github.com/github/super-linter).

According to the previous PR (#95), some warnings and errors are ignored, which can be configurable at `.github/linters/.flake8`.
* E129: visually indented line with same indent as next logical line
* E226: missing whitespace around arithmetic operator
* E303: too many blank lines (X)
* E501: line too long (XX > 79 characters)
* W503: line break before binary operator
* W504: line break after binary operator
* E741: do not use variables named ‘l’, ‘O’, or ‘I’

Additionally, a 3rd party copied file `tf2rl/misc/prepare_output_dir.py` is ignored, too.

---

Some code style is also fixed. (58fb730)
