### PR TITLE
Feature: Trainer without argparse

### DIFF
--- a/tests/experiments/test_trainer.py
+++ b/tests/experiments/test_trainer.py
@@ -39,6 +39,22 @@ class TestTrainer(unittest.TestCase):
         trainer = Trainer(policy, env, {"max_steps": max_steps}, test_env=test_env)
         self.assertEqual(trainer._max_steps, max_steps)
 
+    def test_invalid_args(self):
+        """
+        Test with invalid args
+        """
+        env = gym.make("Pendulum-v0")
+        test_env = gym.make("Pendulum-v0")
+        policy = DDPG(state_shape=env.observation_space.shape,
+                      action_dim=env.action_space.high.size,
+                      gpu=-1,
+                      memory_capacity=1000,
+                      max_action=env.action_space.high[0],
+                      batch_size=32,
+                      n_warmup=10)
+        with self.assertRaises(ValueError):
+            Trainer(policy, env, {"NOT_EXISTING_OPTIONS": 1}, test_env=test_env)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/experiments/test_trainer.py
+++ b/tests/experiments/test_trainer.py
@@ -20,8 +20,7 @@ class TestTrainer(unittest.TestCase):
                       max_action=env.action_space.high[0],
                       batch_size=32,
                       n_warmup=10)
-        trainer = Trainer(policy, env, {}, test_env=test_env)
-        print(trainer)
+        Trainer(policy, env, {}, test_env=test_env)
 
     def test_with_args(self):
         """

--- a/tests/experiments/test_trainer.py
+++ b/tests/experiments/test_trainer.py
@@ -1,0 +1,45 @@
+import unittest
+
+import gym
+
+from tf2rl.algos.ddpg import DDPG
+from tf2rl.experiments.trainer import Trainer
+
+
+class TestTrainer(unittest.TestCase):
+    def test_empty_args(self):
+        """
+        Test empty args {}
+        """
+        env = gym.make("Pendulum-v0")
+        test_env = gym.make("Pendulum-v0")
+        policy = DDPG(state_shape=env.observation_space.shape,
+                      action_dim=env.action_space.high.size,
+                      gpu=-1,
+                      memory_capacity=1000,
+                      max_action=env.action_space.high[0],
+                      batch_size=32,
+                      n_warmup=10)
+        trainer = Trainer(policy, env, {}, test_env=test_env)
+        print(trainer)
+
+    def test_with_args(self):
+        """
+        Test with args
+        """
+        max_steps = 400
+        env = gym.make("Pendulum-v0")
+        test_env = gym.make("Pendulum-v0")
+        policy = DDPG(state_shape=env.observation_space.shape,
+                      action_dim=env.action_space.high.size,
+                      gpu=-1,
+                      memory_capacity=1000,
+                      max_action=env.action_space.high[0],
+                      batch_size=32,
+                      n_warmup=10)
+        trainer = Trainer(policy, env, {"max_steps": max_steps}, test_env=test_env)
+        self.assertEqual(trainer._max_steps, max_steps)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tf2rl/experiments/trainer.py
+++ b/tf2rl/experiments/trainer.py
@@ -27,6 +27,13 @@ class Trainer:
             env,
             args,
             test_env=None):
+        if isinstance(args, dict):
+            _args = args
+            args = policy.__class__.get_argument(Trainer.get_argument())
+            args = args.parse_args([])
+            for k, v in _args.items():
+                setattr(args, k, v)
+
         self._set_from_args(args)
         self._policy = policy
         self._env = env

--- a/tf2rl/experiments/trainer.py
+++ b/tf2rl/experiments/trainer.py
@@ -32,7 +32,10 @@ class Trainer:
             args = policy.__class__.get_argument(Trainer.get_argument())
             args = args.parse_args([])
             for k, v in _args.items():
-                setattr(args, k, v)
+                if hasattr(args, k):
+                    setattr(args, k, v)
+                else:
+                    raise ValueError(f"{k} is invalid parameter.")
 
         self._set_from_args(args)
         self._policy = policy


### PR DESCRIPTION
This PR is related with #104

This PR enables `Trainer` to accept `dict`-type `args` at constructor.

User can pass parameters like followings;
```python
trainer = Trainer(policy,env,{"max_steps": 1000},test_env=test_env)
```

This PR preserves backward compatibility, so that user still can pass `argparse.Namespace` (result of `parse_args()`).