### PR TITLE
Feature: Document Site

### DIFF
--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -1,6 +1,6 @@
 name: Document
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   doc:

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -24,6 +24,7 @@ jobs:
       - run: pip install sphinx sphinx-rtd-theme recommonmark tensorflow
       - run: pip install ".[test]"
       - run: sphinx-apidoc -F -o doc tf2rl/
+      - run: rm doc/index.rst
       - run: sphinx-build -b html doc public
       - uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -30,3 +30,8 @@ jobs:
         with:
           name: doc
           path: public
+      - uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./public
+        if: (github.ref == 'refs/heads/master') && (github.repository == 'keiohta/tf2rl')

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -1,0 +1,31 @@
+name: Document
+
+on: [push]
+
+jobs:
+  doc:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: 3.7
+      - name: Get pip cache dir
+        id: pip-cache
+        run: echo "::set-output name=dir::$(pip cache dir)"
+      - name: pip cache
+        uses: actions/cache@v2
+        with:
+          path: ${{ steps.pip-cache.outputs.dir }}
+          key: sphinx
+          restore-keys: |
+            sphinx
+      - run: pip install wheel
+      - run: pip install sphinx sphinx-rtd-theme recommonmark tensorflow
+      - run: pip install ".[test]"
+      - run: sphinx-apidoc -F -o doc tf2rl/
+      - run: sphinx-build -b html doc public
+      - uses: actions/upload-artifact@v2
+        with:
+          name: doc
+          path: public

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -1,0 +1,7 @@
+project = "TF2RL"
+author = "Kei Ohta"
+copyright = "2020, Kei Ohta"
+
+
+extensions = ["sphinx.ext.autodoc", "recommonmark"]
+html_theme = "sphinx_rtd_theme"

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -8,5 +8,6 @@ copyright = "2020, Kei Ohta"
 extensions = ["sphinx.ext.autodoc", "recommonmark"]
 html_theme = "sphinx_rtd_theme"
 
+
 def setup(app):
     app.add_transform(AutoStructify)

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -1,3 +1,5 @@
+from recommonmark.transform import AutoStructify
+
 project = "TF2RL"
 author = "Kei Ohta"
 copyright = "2020, Kei Ohta"
@@ -5,3 +7,6 @@ copyright = "2020, Kei Ohta"
 
 extensions = ["sphinx.ext.autodoc", "recommonmark"]
 html_theme = "sphinx_rtd_theme"
+
+def setup(app):
+    app.add_transform(AutoStructify)

--- a/doc/index.md
+++ b/doc/index.md
@@ -1,0 +1,20 @@
+# TF2RL
+
+
+
+## Class Reference
+```eval_rst
+.. toctree::
+   :maxdepth: 4
+   :caption: Contents:
+
+   tf2rl
+```
+
+
+## Indices and Tables
+```eval_rst
+* :ref:`genindex`
+* :ref:`modindex`
+* :ref:`search`
+```


### PR DESCRIPTION
This PR for issue #106

This PR creates document site generated by sphinx and publish to GitHub Pages only when master branch.
Publishing is enabled only at "keiohta/tf2rl", not at any fork repos.
(You might need to enable project GitHub Pages manually at the settings tab on your TF2RL repository. Sorry, I'm not sure.)

docstring in TF2RL are automatically extracted and converted to class references.

You can download and see the current candidate site.
https://github.com/ymd-h/tf2rl/actions/runs/235144925

You can edit `index.md` and add any other `.md` or `.rst` format files under `doc` directory.