### PR TITLE
Docker Container Support

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,32 @@
+name: docker
+
+on:
+  push:
+    tags:
+      - '**'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    env:
+      DOCKER_BUILDKIT: 1
+    steps:
+      - uses: actions/checkout@v2
+      - uses: docker/build-push-action@v1
+        with:
+          registry: ghcr.io
+          repository: ${{ github.repository_owner }}/tf2rl/cpu
+          tag_with_ref: true
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GHCR_TOKEN }}
+          dockerfile: Dockerfile
+          always_pull: true
+      - uses: docker/build-push-action@v1
+        with:
+          registry: ghcr.io
+          repository: ${{ github.repository_owner }}/tf2rl/nvidia
+          tag_with_ref: true
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GHCR_TOKEN }}
+          dockerfile: Dockerfile.nvidia
+          always_pull: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,9 +9,17 @@ RUN apt update \
 
 RUN --mount=type=cache,target=/root/.cache/pip \
 	pip install -U \
+	cpprb \
+	joblib \
 	matplotlib \
+	scipy \
 	tensorflow==2.2.* \
-	tensorflow_probability==0.10.* \
-	tf2rl
+	tensorflow_probability==0.10.*
+
+COPY setup.py /tf2rl/setup.py
+COPY tf2rl /tf2rl/tf2rl
+
+RUN pip install /tf2rl tensorflow_probability==0.10.* && rm -rf /tf2rl
+
 
 CMD ["/bin/bash"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+# syntax = docker/dockerfile:experimental
+FROM python:3.7
+
+RUN apt update \
+	&& apt install -y --no-install-recommends \
+	python-opengl \
+	&& apt clean \
+	&& rm -rf /var/lib/apt/lists/*
+
+RUN --mount=type=cache,target=/root/.cache/pip \
+	pip install -U \
+	matplotlib \
+	tensorflow==2.2.* \
+	tensorflow_probability==0.10.* \
+	tf2rl
+
+CMD ["/bin/bash"]

--- a/Dockerfile.nvidia
+++ b/Dockerfile.nvidia
@@ -1,0 +1,20 @@
+# syntax = docker/dockerfile:experimental
+FROM tensorflow/tensorflow:2.2.1-gpu
+
+ENV DEBIAN_FRONTEND noninteractive
+
+RUN apt update \
+	&& apt install -y --no-install-recommends \
+	libopencv-dev \
+	python3-opengl \
+	&& apt clean \
+	&& rm -rf /var/lib/apt/lists/*
+
+
+RUN --mount=type=cache,target=/root/.cache/pip \
+	pip install -U \
+	matplotlib \
+	tensorflow_probability==0.10.* \
+	tf2rl
+
+CMD ["/bin/bash"]

--- a/Dockerfile.nvidia
+++ b/Dockerfile.nvidia
@@ -13,8 +13,15 @@ RUN apt update \
 
 RUN --mount=type=cache,target=/root/.cache/pip \
 	pip install -U \
+	cpprb \
+	joblib \
 	matplotlib \
-	tensorflow_probability==0.10.* \
-	tf2rl
+	scipy \
+	tensorflow_probability==0.10.*
+
+COPY setup.py /tf2rl/setup.py
+COPY tf2rl /tf2rl/tf2rl
+
+RUN pip install /tf2rl tensorflow_probability==0.10.* && rm -rf /tf2rl
 
 CMD ["/bin/bash"]

--- a/README.md
+++ b/README.md
@@ -67,6 +67,66 @@ $ cd tf2rl
 $ pip install .
 ```
 
+### Preinstalled Docker Container
+Instead of installing tf2rl on your (virtual) system, you can use
+preinstalled Docker containers.
+
+Only the first execution requires time to download the container image.
+
+At the following commands, you need to replace `<version>` with the
+version tag which you want to use.
+
+
+#### CPU Only
+
+The following simple command starts preinstalled container.
+
+```bash
+docker run -it ghcr.io/keiohta/tf2rl/cpu:<version> bash
+```
+
+
+If you also want to mount your local directory `/local/dir/path` at
+container `/mount/point`
+
+```bash
+docker run -it -v /local/dir/path:/mount/point ghcr.io/keiohta/tf2rl/cpu:<version> bash
+```
+
+#### GPU Support (Linux Only, Experimental)
+
+WARNING: We encountered unsolved errors when running ApeX multiprocess learning.
+
+Requirements
+- Linux
+- NVIDIA GPU
+  - TF2.2 compatible driver
+- Docker 19.03 or later
+
+
+The following simple command starts preinstalled container.
+
+```bash
+docker run --gpus all -it ghcr.io/keiohta/tf2rl/nvidia:<version> bash
+```
+
+If you also want to mount your local directory `/local/dir/path` at
+container `/mount/point`
+
+
+```bash
+docker run --gpus all -it -v /local/dir/path:/mount/point ghcr.io/keiohta/tf2rl/nvidia:<version> bash
+```
+
+
+If your container can see GPU correctly, you can check inside
+container by the following comand;
+
+```bash
+nvidia-smi
+```
+
+
 ## Getting started
 Here is a quick example of how to train DDPG agent on a Pendulum environment:
 


### PR DESCRIPTION
This PR adds Dockerfiles to build container images for tf2rl (#110)

Two containers are pushed to GitHub Container Registry
- CPU only
- with Nvidia GPU

You need to create personal access token and set it as "GHCR_TOKEN"
