### PR TITLE
Fix: load trajectories with limited max_steps

### DIFF
--- a/tests/experiments/test_utils.py
+++ b/tests/experiments/test_utils.py
@@ -41,6 +41,9 @@ class TestUtils(unittest.TestCase):
         self.assertEqual(data["obses"].shape[0],
                          (self.replay_buffer.get_buffer_size() - 1) * n_store_episodes)
 
+        max_steps = 10
+        data = restore_latest_n_traj(self.output_dir, 1, max_steps)
+        self.assertEqual(data["obses"].shape[0], max_steps)
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/experiments/test_utils.py
+++ b/tests/experiments/test_utils.py
@@ -39,7 +39,7 @@ class TestUtils(unittest.TestCase):
                              "step_0_epi_{}_return_0.0.pkl").format(epi))
         data = restore_latest_n_traj(self.output_dir)
         self.assertEqual(data["obses"].shape[0],
-                         (self.replay_buffer.get_buffer_size() - 1) * n_store_episodes)
+                         self.replay_buffer.get_buffer_size() * n_store_episodes)
 
         max_steps = 10
         data = restore_latest_n_traj(self.output_dir, 1, max_steps)

--- a/tests/experiments/test_utils.py
+++ b/tests/experiments/test_utils.py
@@ -44,6 +44,8 @@ class TestUtils(unittest.TestCase):
         max_steps = 10
         data = restore_latest_n_traj(self.output_dir, 1, max_steps)
         self.assertEqual(data["obses"].shape[0], max_steps)
+        self.assertEqual(data["acts"].shape[0], max_steps)
+        self.assertEqual(data["next_obses"].shape[0], max_steps)
 
 
 if __name__ == '__main__':

--- a/tests/experiments/test_utils.py
+++ b/tests/experiments/test_utils.py
@@ -45,5 +45,6 @@ class TestUtils(unittest.TestCase):
         data = restore_latest_n_traj(self.output_dir, 1, max_steps)
         self.assertEqual(data["obses"].shape[0], max_steps)
 
+
 if __name__ == '__main__':
     unittest.main()

--- a/tf2rl/experiments/utils.py
+++ b/tf2rl/experiments/utils.py
@@ -13,7 +13,7 @@ def save_path(samples, filename):
 def restore_latest_n_traj(dirname, n_path=10, max_steps=None):
     assert os.path.isdir(dirname)
     filenames = get_filenames(dirname, n_path)
-    return load_trajectories(filenames, None)
+    return load_trajectories(filenames, max_steps)
 
 
 def get_filenames(dirname, n_path=None):

--- a/tf2rl/experiments/utils.py
+++ b/tf2rl/experiments/utils.py
@@ -48,7 +48,7 @@ def load_trajectories(filenames, max_steps=None):
         next_obses = path['obs'][1:]
         actions = path['act'][:-1]
         if max_steps is not None:
-            return obses[:max_steps], next_obses[:max_steps], actions[:max_steps-1]
+            return obses[:max_steps], next_obses[:max_steps], actions[:max_steps]
         else:
             return obses, next_obses, actions
 

--- a/tf2rl/experiments/utils.py
+++ b/tf2rl/experiments/utils.py
@@ -44,9 +44,9 @@ def load_trajectories(filenames, max_steps=None):
         paths.append(joblib.load(filename))
 
     def get_obs_and_act(path):
-        obses = path['obs'][:-1]
-        next_obses = path['obs'][1:]
-        actions = path['act'][:-1]
+        obses = path['obs']
+        next_obses = path['next_obs']
+        actions = path['act']
         if max_steps is not None:
             return obses[:max_steps], next_obses[:max_steps], actions[:max_steps]
         else:


### PR DESCRIPTION
This PR for #144 and #145.


* Pass `max_steps` from `restore_latest_n_traj` to `load_trajectories`
* Use same length (aka. `max_steps`) for `actions`
* Add test to check above fixes