### PR TITLE
Fast random sampling for IRL

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,8 +53,9 @@ jobs:
       - name: Install cpprb for macOS
         if: startsWith(runner.os, 'macOS')
         run: CC=gcc-9 CXX=g++-9 pip install cpprb
-      - run: pip install tensorflow==${{ matrix.TF }}'.*' atari-py
+      - run: pip install tensorflow==${{ matrix.TF }}'.*'
       - run: pip install '.[test]'
+      - run: pip install -U atari-py
       - name: Install TensorFlow Probability
         if: ${{ matrix.TF == '2.0' }}
         run: pip install tensorflow-probability==0.8.0 gast==0.2.2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Install cpprb for macOS
         if: startsWith(runner.os, 'macOS')
         run: CC=gcc-9 CXX=g++-9 pip install cpprb
-      - run: pip install tensorflow==${{ matrix.TF }}'.*'
+      - run: pip install tensorflow==${{ matrix.TF }}'.*' atari-py
       - run: pip install '.[test]'
       - name: Install TensorFlow Probability
         if: ${{ matrix.TF == '2.0' }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -72,13 +72,13 @@ jobs:
         if: ${{ matrix.TF == '2.4' }}
         run: pip install tensorflow-probability==0.12.0 gast==0.3.3
       - name: Install ROM of atari games for Ubuntu
-        if: ${{ matrix.TF >= '2.2' && matrix.os == 'ubuntu-latest' }}
+        if: ${{ matrix.os == 'ubuntu-latest' }}
         run: wget http://www.atarimania.com/roms/Roms.rar && 7z x Roms.rar && unzip ROMS.zip && python -m atari_py.import_roms ROMS
       - name: Install ROM of atari games for MacOS
-        if: ${{ matrix.TF >= '2.2' && matrix.os == 'macos-latest' }}
+        if: ${{ matrix.os == 'macos-latest' }}
         run: brew install rar && wget http://www.atarimania.com/roms/Roms.rar && unrar x Roms.rar && ditto -V -x -k --sequesterRsrc ROMS.zip . && python -m atari_py.import_roms ROMS
       - name: Install ROM of atari games for Windows
-        if: ${{ matrix.TF >= '2.2' && matrix.os == 'windows-latest' }}
+        if: ${{ matrix.os == 'windows-latest' }}
         run: C:\msys64\usr\bin\wget.exe http://www.atarimania.com/roms/Roms.rar && 7z x Roms.rar && unzip ROMS.zip && python -m atari_py.import_roms ROMS
       - run: python -m unittest discover .
         working-directory: './tests'

--- a/tf2rl/experiments/irl_trainer.py
+++ b/tf2rl/experiments/irl_trainer.py
@@ -1,3 +1,4 @@
+import random
 import time
 
 import numpy as np
@@ -102,8 +103,8 @@ class IRLTrainer(Trainer):
                     for _ in range(self._irl.n_training):
                         samples = replay_buffer.sample(self._irl.batch_size)
                         # Do not allow duplication!!!
-                        indices = np.random.choice(
-                            self._random_range, self._irl.batch_size, replace=False)
+                        indices = random.sample(
+                            range(self._random_range), self._irl.batch_size)
                         self._irl.train(
                             agent_states=samples["obs"],
                             agent_acts=samples["act"],


### PR DESCRIPTION
This PR includes followings;

* Use random.sample (Python standard library) instead of np.random.choice (#126)
* Update atari-py from 0.2.6 ([yanked version](https://pypi.org/project/atari-py/#history)) to 0.2.9+
  * Unfortunately, gym["atari"] specifies atari-py==0.2.6 ([ref](https://github.com/openai/gym/blob/150404104afc57ea618acca34d2d1f797d779869/setup.py#L12)), so that I manually overwrite
* Install ROM for TF < 2.2, too.
  * #138 installs ROM only for TF 2.2+