### PR TITLE
Fix: DeprecatedEnv error for Pendulum-v0

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,8 +153,8 @@ parser = Trainer.get_argument()
 parser = DDPG.get_argument(parser)
 args = parser.parse_args()
 
-env = gym.make("Pendulum-v0")
-test_env = gym.make("Pendulum-v0")
+env = gym.make("Pendulum-v1")
+test_env = gym.make("Pendulum-v1")
 policy = DDPG(
     state_shape=env.observation_space.shape,
     action_dim=env.action_space.high.size,

--- a/examples/run_apex_ddpg.py
+++ b/examples/run_apex_ddpg.py
@@ -1,8 +1,7 @@
-import gym
-
 from tf2rl.algos.apex import apex_argument, run
 from tf2rl.algos.ddpg import DDPG
 from tf2rl.misc.target_update_ops import update_target_variables
+from tf2rl.envs.utils import make
 
 
 # Prepare env and policy function
@@ -11,7 +10,7 @@ class env_fn:
         self.env_name = env_name
 
     def __call__(self):
-        return gym.make(self.env_name)
+        return make(self.env_name)
 
 
 def policy_fn(env, name, memory_capacity=int(1e6),

--- a/examples/run_apex_dqn.py
+++ b/examples/run_apex_dqn.py
@@ -1,10 +1,10 @@
-import gym
 import tensorflow as tf
 
 from tf2rl.algos.apex import apex_argument, run
 from tf2rl.algos.dqn import DQN
 from tf2rl.misc.target_update_ops import update_target_variables
 from tf2rl.networks.atari_model import AtariQFunc
+from tf2rl.envs.utils import make
 
 
 # Prepare env and policy function
@@ -13,7 +13,7 @@ class env_fn:
         self.env_name = env_name
 
     def __call__(self):
-        return gym.make(self.env_name)
+        return make(self.env_name)
 
 
 class policy_fn:

--- a/examples/run_bi_res_ddpg.py
+++ b/examples/run_bi_res_ddpg.py
@@ -1,8 +1,6 @@
-import gym
-
 from tf2rl.algos.bi_res_ddpg import BiResDDPG
 from tf2rl.experiments.trainer import Trainer
-
+from tf2rl.envs.utils import make
 
 if __name__ == '__main__':
     parser = Trainer.get_argument()
@@ -12,8 +10,8 @@ if __name__ == '__main__':
     parser.set_defaults(n_warmup=10000)
     args = parser.parse_args()
 
-    env = gym.make(args.env_name)
-    test_env = gym.make(args.env_name)
+    env = make(args.env_name)
+    test_env = make(args.env_name)
     policy = BiResDDPG(
         state_shape=env.observation_space.shape,
         action_dim=env.action_space.high.size,

--- a/examples/run_categorical_dqn.py
+++ b/examples/run_categorical_dqn.py
@@ -1,8 +1,6 @@
-import gym
-
 from tf2rl.algos.categorical_dqn import CategoricalDQN
 from tf2rl.experiments.trainer import Trainer
-
+from tf2rl.envs.utils import make
 
 if __name__ == '__main__':
     parser = Trainer.get_argument()
@@ -16,8 +14,8 @@ if __name__ == '__main__':
     parser.add_argument('--env-name', type=str, default="CartPole-v0")
     args = parser.parse_args()
 
-    env = gym.make(args.env_name)
-    test_env = gym.make(args.env_name)
+    env = make(args.env_name)
+    test_env = make(args.env_name)
     policy = CategoricalDQN(
         enable_double_dqn=args.enable_double_dqn,
         enable_dueling_dqn=args.enable_dueling_dqn,

--- a/examples/run_d2rl_sac.py
+++ b/examples/run_d2rl_sac.py
@@ -1,8 +1,6 @@
-import gym
-
 from tf2rl.algos.d2rl_sac import D2RLSAC
 from tf2rl.experiments.trainer import Trainer
-
+from tf2rl.envs.utils import make
 
 if __name__ == '__main__':
     parser = Trainer.get_argument()
@@ -13,8 +11,8 @@ if __name__ == '__main__':
     parser.set_defaults(max_steps=3e6)
     args = parser.parse_args()
 
-    env = gym.make(args.env_name)
-    test_env = gym.make(args.env_name)
+    env = make(args.env_name)
+    test_env = make(args.env_name)
     policy = D2RLSAC(
         state_shape=env.observation_space.shape,
         action_dim=env.action_space.high.size,

--- a/examples/run_ddpg.py
+++ b/examples/run_ddpg.py
@@ -1,8 +1,6 @@
-import gym
-
 from tf2rl.algos.ddpg import DDPG
 from tf2rl.experiments.trainer import Trainer
-
+from tf2rl.envs.utils import make
 
 if __name__ == '__main__':
     parser = Trainer.get_argument()
@@ -12,8 +10,8 @@ if __name__ == '__main__':
     parser.set_defaults(n_warmup=10000)
     args = parser.parse_args()
 
-    env = gym.make(args.env_name)
-    test_env = gym.make(args.env_name)
+    env = make(args.env_name)
+    test_env = make(args.env_name)
     policy = DDPG(
         state_shape=env.observation_space.shape,
         action_dim=env.action_space.high.size,

--- a/examples/run_dqn.py
+++ b/examples/run_dqn.py
@@ -1,8 +1,6 @@
-import gym
-
 from tf2rl.algos.dqn import DQN
 from tf2rl.experiments.trainer import Trainer
-
+from tf2rl.envs.utils import make
 
 if __name__ == '__main__':
     parser = Trainer.get_argument()
@@ -16,8 +14,8 @@ if __name__ == '__main__':
     parser.add_argument('--env-name', type=str, default="CartPole-v0")
     args = parser.parse_args()
 
-    env = gym.make(args.env_name)
-    test_env = gym.make(args.env_name)
+    env = make(args.env_name)
+    test_env = make(args.env_name)
     policy = DQN(
         enable_double_dqn=args.enable_double_dqn,
         enable_dueling_dqn=args.enable_dueling_dqn,

--- a/examples/run_dqn_atari.py
+++ b/examples/run_dqn_atari.py
@@ -1,10 +1,8 @@
-import gym
-
 from tf2rl.algos.dqn import DQN
 from tf2rl.envs.atari_wrapper import wrap_dqn
 from tf2rl.experiments.trainer import Trainer
 from tf2rl.networks.atari_model import AtariQFunc as QFunc
-
+from tf2rl.envs.utils import make
 
 if __name__ == '__main__':
     parser = Trainer.get_argument()
@@ -20,8 +18,8 @@ if __name__ == '__main__':
     parser.set_defaults(memory_capacity=int(1e6))
     args = parser.parse_args()
 
-    env = wrap_dqn(gym.make(args.env_name))
-    test_env = wrap_dqn(gym.make(args.env_name), reward_clipping=False)
+    env = wrap_dqn(make(args.env_name))
+    test_env = wrap_dqn(make(args.env_name), reward_clipping=False)
     # Following parameters are equivalent to DeepMind DQN paper
     # https://www.nature.com/articles/nature14236
     policy = DQN(

--- a/examples/run_gaifo_ddpg.py
+++ b/examples/run_gaifo_ddpg.py
@@ -1,10 +1,8 @@
-import gym
-
 from tf2rl.algos.ddpg import DDPG
 from tf2rl.algos.gaifo import GAIfO
 from tf2rl.experiments.irl_trainer import IRLTrainer
 from tf2rl.experiments.utils import restore_latest_n_traj
-
+from tf2rl.envs.utils import make
 
 if __name__ == '__main__':
     parser = IRLTrainer.get_argument()
@@ -19,8 +17,8 @@ if __name__ == '__main__':
 
     units = [400, 300]
 
-    env = gym.make(args.env_name)
-    test_env = gym.make(args.env_name)
+    env = make(args.env_name)
+    test_env = make(args.env_name)
     policy = DDPG(
         state_shape=env.observation_space.shape,
         action_dim=env.action_space.high.size,

--- a/examples/run_gail_ddpg.py
+++ b/examples/run_gail_ddpg.py
@@ -1,10 +1,8 @@
-import gym
-
 from tf2rl.algos.ddpg import DDPG
 from tf2rl.algos.gail import GAIL
 from tf2rl.experiments.irl_trainer import IRLTrainer
 from tf2rl.experiments.utils import restore_latest_n_traj
-
+from tf2rl.envs.utils import make
 
 if __name__ == '__main__':
     parser = IRLTrainer.get_argument()
@@ -19,8 +17,8 @@ if __name__ == '__main__':
 
     units = [400, 300]
 
-    env = gym.make(args.env_name)
-    test_env = gym.make(args.env_name)
+    env = make(args.env_name)
+    test_env = make(args.env_name)
     policy = DDPG(
         state_shape=env.observation_space.shape,
         action_dim=env.action_space.high.size,

--- a/examples/run_me_trpo.py
+++ b/examples/run_me_trpo.py
@@ -1,7 +1,5 @@
-import gym
-
 from tf2rl.algos.ppo import PPO
-from tf2rl.envs.utils import is_discrete, get_act_dim
+from tf2rl.envs.utils import is_discrete, get_act_dim, make
 from tf2rl.experiments.me_trpo_trainer import MeTrpoTrainer
 from examples.run_mpc import reward_fn_pendulum
 
@@ -16,8 +14,8 @@ if __name__ == "__main__":
 
     args.n_generate_steps = args.horizon
 
-    env = gym.make("Pendulum-v0")
-    test_env = gym.make("Pendulum-v0")
+    env = make("Pendulum-v0")
+    test_env = make("Pendulum-v0")
 
     policy = PPO(
         state_shape=env.observation_space.shape,

--- a/examples/run_mpc.py
+++ b/examples/run_mpc.py
@@ -1,6 +1,6 @@
-import gym
 import numpy as np
 from tf2rl.experiments.mpc_trainer import MPCTrainer, RandomPolicy
+from tf2rl.envs.utils import make
 
 
 def angle_normalize(x):
@@ -31,8 +31,8 @@ if __name__ == "__main__":
     parser.set_defaults(episode_max_steps=200)
     args = parser.parse_args()
 
-    env = gym.make("Pendulum-v0")
-    test_env = gym.make("Pendulum-v0")
+    env = make("Pendulum-v0")
+    test_env = make("Pendulum-v0")
 
     policy = RandomPolicy(
         max_action=env.action_space.high[0],

--- a/examples/run_ppo.py
+++ b/examples/run_ppo.py
@@ -1,8 +1,6 @@
-import gym
-
 from tf2rl.algos.ppo import PPO
 from tf2rl.experiments.on_policy_trainer import OnPolicyTrainer
-from tf2rl.envs.utils import is_discrete, get_act_dim
+from tf2rl.envs.utils import is_discrete, get_act_dim, make
 
 
 if __name__ == '__main__':
@@ -18,8 +16,8 @@ if __name__ == '__main__':
     parser.set_defaults(gpu=-1)
     args = parser.parse_args()
 
-    env = gym.make(args.env_name)
-    test_env = gym.make(args.env_name)
+    env = make(args.env_name)
+    test_env = make(args.env_name)
 
     policy = PPO(
         state_shape=env.observation_space.shape,

--- a/examples/run_ppo_atari.py
+++ b/examples/run_ppo_atari.py
@@ -1,11 +1,8 @@
-import gym
-
-
 from tf2rl.algos.ppo import PPO
 from tf2rl.envs.atari_wrapper import wrap_dqn
 from tf2rl.experiments.on_policy_trainer import OnPolicyTrainer
 from tf2rl.networks.atari_model import AtariCategoricalActorCritic
-
+from tf2rl.envs.utils import make
 
 if __name__ == '__main__':
     parser = OnPolicyTrainer.get_argument()
@@ -21,8 +18,8 @@ if __name__ == '__main__':
     parser.set_defaults(show_test_images=True)
     args = parser.parse_args()
 
-    env = wrap_dqn(gym.make(args.env_name))
-    test_env = wrap_dqn(gym.make(args.env_name), reward_clipping=False)
+    env = wrap_dqn(make(args.env_name))
+    test_env = wrap_dqn(make(args.env_name), reward_clipping=False)
 
     state_shape = env.observation_space.shape
     action_dim = env.action_space.n

--- a/examples/run_sac.py
+++ b/examples/run_sac.py
@@ -1,8 +1,6 @@
-import gym
-
 from tf2rl.algos.sac import SAC
 from tf2rl.experiments.trainer import Trainer
-
+from tf2rl.envs.utils import make
 
 if __name__ == '__main__':
     parser = Trainer.get_argument()
@@ -13,8 +11,8 @@ if __name__ == '__main__':
     parser.set_defaults(max_steps=3e6)
     args = parser.parse_args()
 
-    env = gym.make(args.env_name)
-    test_env = gym.make(args.env_name)
+    env = make(args.env_name)
+    test_env = make(args.env_name)
     policy = SAC(
         state_shape=env.observation_space.shape,
         action_dim=env.action_space.high.size,

--- a/examples/run_sac_discrete.py
+++ b/examples/run_sac_discrete.py
@@ -1,11 +1,9 @@
-import gym
-
 from tf2rl.algos.sac_discrete import SACDiscrete
 from tf2rl.experiments.trainer import Trainer
 from tf2rl.envs.utils import is_atari_env
 from tf2rl.envs.atari_wrapper import wrap_dqn
 from tf2rl.networks.atari_model import AtariQFunc, AtariCategoricalActor
-
+from tf2rl.envs.utils import make
 
 if __name__ == '__main__':
     parser = Trainer.get_argument()
@@ -20,8 +18,8 @@ if __name__ == '__main__':
                         default="SpaceInvadersNoFrameskip-v4")
     args = parser.parse_args()
 
-    env = gym.make(args.env_name)
-    test_env = gym.make(args.env_name)
+    env = make(args.env_name)
+    test_env = make(args.env_name)
 
     if is_atari_env(env):
         # Parameters come from Appendix.B in original paper.

--- a/examples/run_td3.py
+++ b/examples/run_td3.py
@@ -1,8 +1,6 @@
-import gym
-
 from tf2rl.algos.td3 import TD3
 from tf2rl.experiments.trainer import Trainer
-
+from tf2rl.envs.utils import make
 
 if __name__ == '__main__':
     parser = Trainer.get_argument()
@@ -12,8 +10,8 @@ if __name__ == '__main__':
     parser.set_defaults(n_warmup=10000)
     args = parser.parse_args()
 
-    env = gym.make(args.env_name)
-    test_env = gym.make(args.env_name)
+    env = make(args.env_name)
+    test_env = make(args.env_name)
     policy = TD3(
         state_shape=env.observation_space.shape,
         action_dim=env.action_space.high.size,

--- a/examples/run_vail_ddpg.py
+++ b/examples/run_vail_ddpg.py
@@ -1,10 +1,8 @@
-import gym
-
 from tf2rl.algos.ddpg import DDPG
 from tf2rl.algos.vail import VAIL
 from tf2rl.experiments.irl_trainer import IRLTrainer
 from tf2rl.experiments.utils import restore_latest_n_traj
-
+from tf2rl.envs.utils import make
 
 if __name__ == '__main__':
     parser = IRLTrainer.get_argument()
@@ -19,8 +17,8 @@ if __name__ == '__main__':
 
     units = [400, 300]
 
-    env = gym.make(args.env_name)
-    test_env = gym.make(args.env_name)
+    env = make(args.env_name)
+    test_env = make(args.env_name)
     policy = DDPG(
         state_shape=env.observation_space.shape,
         action_dim=env.action_space.high.size,

--- a/examples/run_vpg.py
+++ b/examples/run_vpg.py
@@ -1,8 +1,6 @@
-import gym
-
 from tf2rl.algos.vpg import VPG
 from tf2rl.experiments.on_policy_trainer import OnPolicyTrainer
-from tf2rl.envs.utils import is_discrete, get_act_dim
+from tf2rl.envs.utils import is_discrete, get_act_dim, make
 
 
 if __name__ == '__main__':
@@ -17,8 +15,8 @@ if __name__ == '__main__':
     parser.set_defaults(gpu=-1)
     args = parser.parse_args()
 
-    env = gym.make(args.env_name)
-    test_env = gym.make(args.env_name)
+    env = make(args.env_name)
+    test_env = make(args.env_name)
     policy = VPG(
         state_shape=env.observation_space.shape,
         action_dim=get_act_dim(env.action_space),

--- a/setup.py
+++ b/setup.py
@@ -34,11 +34,18 @@ if not (platform.system() == 'Windows' and tf_version == "2.0"):
     # tensorflow-addons does not support tf2.0 on Windows
     install_requires.append(*compatible_tfa[tf_version])
 
+
+compatible_gym = {
+    "2.0": "gym[atari]<0.21.0",
+    "2.1": "gym[atari]<0.21.0"
+}
+gym_version = compatible_gym.get(tf_version, "gym[atari]>=0.21.0")
+
 extras_require = {
     "tf": ["tensorflow>=2.0.0"],
     "tf_gpu": ["tensorflow-gpu>=2.0.0"],
-    "examples": ["gym[atari]", "opencv-python"],
-    "test": ["coveralls", "gym[atari]", "matplotlib", "opencv-python", "future"]
+    "examples": [gym_version, "opencv-python"],
+    "test": ["coveralls", gym_version, "matplotlib", "opencv-python", "future"]
 }
 
 setup(

--- a/tests/algos/common.py
+++ b/tests/algos/common.py
@@ -2,6 +2,8 @@ import unittest
 import numpy as np
 import gym
 
+from tf2rl.envs.utils import make
+
 
 class DummyImgEnv(gym.Env):
     def __init__(self, img_dim=84):
@@ -19,8 +21,8 @@ class CommonAlgos(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         # TODO: Remove dependencies to gym
-        cls.discrete_env = gym.make("CartPole-v0")
-        cls.continuous_env = gym.make("Pendulum-v0")
+        cls.discrete_env = make("CartPole-v0")
+        cls.continuous_env = make("Pendulum-v0")
         cls.batch_size = 32
         cls.agent = None
 

--- a/tests/algos/test_apex.py
+++ b/tests/algos/test_apex.py
@@ -1,10 +1,10 @@
 # Hard to test each function, so just execute shortly
 
 import unittest
-import gym
 
 from tf2rl.algos.apex import apex_argument, run
 from tf2rl.misc.target_update_ops import update_target_variables
+from tf2rl.envs.utils import make
 
 
 class TestApeX(unittest.TestCase):
@@ -38,7 +38,7 @@ class TestApeX(unittest.TestCase):
 
 
 def env_fn_discrete():
-    return gym.make("CartPole-v0")
+    return make("CartPole-v0")
 
 
 def policy_fn_discrete(env, name, memory_capacity=int(1e6), gpu=-1, *args, **kwargs):
@@ -69,7 +69,7 @@ def set_weights_fn_discrete(policy, weights):
 
 
 def env_fn_continuous():
-    return gym.make('Pendulum-v0')
+    return make('Pendulum-v0')
 
 
 def policy_fn_continuous(env, name, memory_capacity=int(1e6), gpu=-1, *args, **kwargs):

--- a/tests/envs/test_atari_wrapper.py
+++ b/tests/envs/test_atari_wrapper.py
@@ -3,16 +3,16 @@ import platform
 import unittest
 
 import numpy as np
-import gym
 
 from tf2rl.envs.atari_wrapper import wrap_dqn
+from tf2rl.envs.utils import make
 
 
 @unittest.skipIf((platform.system() == 'Windows') and (sys.version_info.minor >= 8),
                  "atari-py doesn't work at Windows with Python3.8 and later")
 class TestAtariWrapper(unittest.TestCase):
     def test_wrap_dqn(self):
-        env = wrap_dqn(gym.make("SpaceInvadersNoFrameskip-v4"), wrap_ndarray=True)
+        env = wrap_dqn(make("SpaceInvadersNoFrameskip-v4"), wrap_ndarray=True)
 
         obs = env.reset()
         self.assertEqual(type(obs), np.ndarray)

--- a/tests/envs/test_multi_thread_env.py
+++ b/tests/envs/test_multi_thread_env.py
@@ -1,8 +1,8 @@
 import unittest
-import gym
 import tensorflow as tf
 
 from tf2rl.envs.multi_thread_env import MultiThreadEnv
+from tf2rl.envs.utils import make
 
 
 class TestMultiThreadEnv(unittest.TestCase):
@@ -13,7 +13,7 @@ class TestMultiThreadEnv(unittest.TestCase):
         cls.max_episode_steps = 1000
 
         def env_fn():
-            return gym.make("Pendulum-v0")
+            return make("Pendulum-v0")
 
         cls.continuous_sample_env = env_fn()
         cls.continuous_envs = MultiThreadEnv(
@@ -22,7 +22,7 @@ class TestMultiThreadEnv(unittest.TestCase):
             max_episode_steps=cls.max_episode_steps)
 
         def env_fn():
-            return gym.make("CartPole-v0")
+            return make("CartPole-v0")
 
         cls.discrete_sample_env = env_fn()
         cls.discrete_envs = MultiThreadEnv(

--- a/tests/envs/test_utils.py
+++ b/tests/envs/test_utils.py
@@ -1,13 +1,12 @@
 import unittest
-import gym
 
-from tf2rl.envs.utils import is_discrete
+from tf2rl.envs.utils import is_discrete, make
 
 
 class TestUtils(unittest.TestCase):
     def test_is_discrete(self):
-        discrete_space = gym.make('CartPole-v0').action_space
-        continuous_space = gym.make('Pendulum-v0').action_space
+        discrete_space = make('CartPole-v0').action_space
+        continuous_space = make('Pendulum-v0').action_space
         self.assertTrue(is_discrete(discrete_space))
         self.assertFalse(is_discrete(continuous_space))
 

--- a/tests/experiments/test_trainer.py
+++ b/tests/experiments/test_trainer.py
@@ -1,9 +1,8 @@
 import unittest
 
-import gym
-
 from tf2rl.algos.ddpg import DDPG
 from tf2rl.experiments.trainer import Trainer
+from tf2rl.envs.utils import make
 
 
 class TestTrainer(unittest.TestCase):
@@ -11,8 +10,8 @@ class TestTrainer(unittest.TestCase):
         """
         Test empty args {}
         """
-        env = gym.make("Pendulum-v0")
-        test_env = gym.make("Pendulum-v0")
+        env = make("Pendulum-v0")
+        test_env = make("Pendulum-v0")
         policy = DDPG(state_shape=env.observation_space.shape,
                       action_dim=env.action_space.high.size,
                       gpu=-1,
@@ -27,8 +26,8 @@ class TestTrainer(unittest.TestCase):
         Test with args
         """
         max_steps = 400
-        env = gym.make("Pendulum-v0")
-        test_env = gym.make("Pendulum-v0")
+        env = make("Pendulum-v0")
+        test_env = make("Pendulum-v0")
         policy = DDPG(state_shape=env.observation_space.shape,
                       action_dim=env.action_space.high.size,
                       gpu=-1,
@@ -43,8 +42,8 @@ class TestTrainer(unittest.TestCase):
         """
         Test with invalid args
         """
-        env = gym.make("Pendulum-v0")
-        test_env = gym.make("Pendulum-v0")
+        env = make("Pendulum-v0")
+        test_env = make("Pendulum-v0")
         policy = DDPG(state_shape=env.observation_space.shape,
                       action_dim=env.action_space.high.size,
                       gpu=-1,

--- a/tests/experiments/test_utils.py
+++ b/tests/experiments/test_utils.py
@@ -2,17 +2,17 @@ import unittest
 
 import os
 import numpy as np
-import gym
 
 from tf2rl.misc.get_replay_buffer import get_replay_buffer
 from tf2rl.experiments.utils import save_path, restore_latest_n_traj
 from tf2rl.algos.dqn import DQN
+from tf2rl.envs.utils import make
 
 
 class TestUtils(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
-        cls.env = gym.make("CartPole-v0")
+        cls.env = make("CartPole-v0")
         policy = DQN(
             state_shape=cls.env.observation_space.shape,
             action_dim=cls.env.action_space.n,

--- a/tests/misc/test_get_replay_buffer.py
+++ b/tests/misc/test_get_replay_buffer.py
@@ -1,12 +1,11 @@
 import unittest
 
-import gym
-
 from cpprb import ReplayBuffer
 from cpprb import PrioritizedReplayBuffer
 
 from tf2rl.misc.get_replay_buffer import get_replay_buffer
 from tf2rl.algos.policy_base import OnPolicyAgent, OffPolicyAgent
+from tf2rl.envs.utils import make
 
 
 class TestGetReplayBuffer(unittest.TestCase):
@@ -20,8 +19,8 @@ class TestGetReplayBuffer(unittest.TestCase):
         cls.off_policy_agent = OffPolicyAgent(
             name="OffPolicyAgent",
             memory_capacity=cls.memory_capacity)
-        cls.discrete_env = gym.make("CartPole-v0")
-        cls.continuous_env = gym.make("Pendulum-v0")
+        cls.discrete_env = make("CartPole-v0")
+        cls.continuous_env = make("Pendulum-v0")
 
     def test_get_replay_buffer(self):
         # Replay Buffer

--- a/tf2rl/envs/atari_wrapper.py
+++ b/tf2rl/envs/atari_wrapper.py
@@ -30,6 +30,8 @@ import cv2
 from gym import spaces
 import gym
 
+from tf2rl.envs.utils import make
+
 os.environ.setdefault('PATH', '')
 cv2.ocl.setUseOpenCL(False)
 
@@ -343,7 +345,7 @@ class NdarrayFrames(gym.Wrapper):
 
 
 def make_atari(env_id, max_episode_steps=None):
-    env = gym.make(env_id)
+    env = make(env_id)
     assert 'NoFrameskip' in env.spec.id
     env = NoopResetEnv(env, noop_max=30)
     env = MaxAndSkipEnv(env, skip=4)

--- a/tf2rl/envs/utils.py
+++ b/tf2rl/envs/utils.py
@@ -1,5 +1,17 @@
+from logging import getLogger
+
 import gym
 from gym.spaces import Discrete, Box
+
+try:
+    # gym >= 0.21.0
+    from gym.envs.atari import AtariEnv
+except ImportError:
+    # gym < 0.21.0
+    from gym.envs.atari.atari_env import AtariEnv
+
+
+logger = getLogger(__file__)
 
 
 def is_discrete(space):
@@ -29,4 +41,35 @@ def is_mujoco_env(env):
 def is_atari_env(env):
     if not hasattr(env, "env"):
         return False
-    return gym.envs.atari.atari_env.AtariEnv == env.env.__class__
+    return AtariEnv == env.env.__class__
+
+
+def make(id, **kwargs):
+    r"""
+    Make gym.Env with version tolerance
+
+    Args:
+        id (str) : Id specifying `gym.Env` registered to `gym.env.registry`.
+                   Valid format is `"^(?:[\w:-]+\/)?([\w:.-]+)-v(\d+)$"`
+                   See https://github.com/openai/gym/blob/v0.21.0/gym/envs/registration.py#L17-L19
+
+    Returns:
+        gym.Env : Environment
+    """
+    try:
+        return gym.make(id, **kwargs)
+    except gym.error.DeprecatedEnv:
+        # `gym.make` (v0.21.0) check only version mismatch for `DeprecatedEnv`.
+        # https://github.com/openai/gym/blob/v0.21.0/gym/envs/registration.py#L162-L189
+        logger.warning(f"Version Mismatch: {id}")
+        env_idv = id.rsplit("-v", 1)
+
+        candidate = [e for e in gym.envs.registry.env_specs.keys()
+                     if env_idv[0] == e.rsplit("-v", 1)[0]]
+        if len(candidate) == 0:
+            raise
+
+        new_v = max(map(lambda _id: int(_id.rsplit("-v", 1)[1]), candidate))
+        id = f"{env_idv[0]}-v{new_v}"
+        logger.warning(f"Use {id}")
+        return gym.make(id, **kwargs)


### PR DESCRIPTION
This PR is for issue #154.

Pendulum-v0 is deprecated at Gym 0.21.0 and `gym.make` raises
`gym.error.DeprecatedEnv`.

Since TensorFlow 0.8.0 (for TensorFlow 2.0/2.1) is incompatible with
Gym 0.21.0, we cannot increase dependent Gym version.

This commit includes following workaround.

Add a wrapper function tf2rl.envs.utils.make:
  Find latest version from registered environments when
  `DeprecatedEnv` is raised.

  `gym.make` does not check version number when rasing
  `gym.error.DeprecatedEnv`.

  If we pass a future version like "Pendulum-v1000", `gym.make` still
  raises `gym.error.DeprecatedEnv`, so that incremental version check
  can fall into infinit loop.